### PR TITLE
Add helm-match

### DIFF
--- a/alect-themes.el
+++ b/alect-themes.el
@@ -1033,6 +1033,7 @@ For INVERT, see `alect-get-color'."
          (helm-buffer-process     ((,c :foreground ,(gc 'green+1))))
          (helm-buffer-size        ((,c :foreground ,(gc 'cyan))))
          (helm-grep-file          ((,c :inherit compilation-info)))
+		 (helm-match              ((,c :foreground ,(gc 'green))))
 
          ;; help
          (help-argument-name ((,c :inherit font-lock-variable-name-face)))


### PR DESCRIPTION
This commit adds specifications for an important face, helm-match. It is used to display matching parts lines during the full-text with helm-occur. Green color "(gc 'green)" is used for this face.